### PR TITLE
[#24] 서버 애플리케이션 실행 시 JSONException 클래스를 찾지 못하는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     // json
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.json:json:20220924'
 
     // data
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.4'

--- a/src/main/java/org/threefour/ddip/address/controller/AddressController.java
+++ b/src/main/java/org/threefour/ddip/address/controller/AddressController.java
@@ -1,7 +1,7 @@
 package org.threefour.ddip.address.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.json.JSONException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/org/threefour/ddip/address/service/AddressService.java
+++ b/src/main/java/org/threefour/ddip/address/service/AddressService.java
@@ -1,6 +1,6 @@
 package org.threefour.ddip.address.service;
 
-import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.json.JSONException;
 import org.threefour.ddip.address.domain.Address;
 
 public interface AddressService {

--- a/src/main/java/org/threefour/ddip/address/service/AddressServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/address/service/AddressServiceImpl.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.configurationprocessor.json.JSONException;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,7 +51,7 @@ public class AddressServiceImpl implements AddressService {
     ResponseEntity<String> response = restTemplate.exchange(
             url,
             HttpMethod.GET,
-            new org.springframework.http.HttpEntity<>(headers),
+            new HttpEntity<>(headers),
             String.class
     );
     //System.out.println("@response " + response); 뽑았당~!


### PR DESCRIPTION
## resolve #24

## 추가사항
- org.json:json 의존성 추가

## 변경사항
- JSONException 클래스의 소스를 org.springframework.boot.configurationprocessor.json에서 org.json으로 변경
- JSONObject 클래스의 소스를 org.springframework.boot.configurationprocessor.json에서 org.json으로 변경

## 참고자료
https://stackoverflow.com/questions/73071773/how-to-fix-java-lang-classnotfoundexception-org-springframework-boot-configurat

## 배포
- [x] 확인