### PR TITLE
[#37] 대상 도메인의 이미지 저장 기능 추가

### DIFF
--- a/src/main/java/org/threefour/ddip/image/domain/Image.java
+++ b/src/main/java/org/threefour/ddip/image/domain/Image.java
@@ -1,0 +1,36 @@
+package org.threefour.ddip.image.domain;
+
+import lombok.NoArgsConstructor;
+import org.threefour.ddip.audit.BaseGeneraltEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Image extends BaseGeneraltEntity {
+    @Column(nullable = false, length = 20)
+    private TargetType targetType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(name = "s3_url", nullable = false, length = 500)
+    private String s3Url;
+
+    private Image(TargetType targetType, Long targetId, String s3Url) {
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.s3Url = s3Url;
+    }
+
+    public static Image of(TargetType targetType, Long targetId, String s3Url) {
+        return new Image(targetType, targetId, s3Url);
+    }
+
+    public String getS3Url() {
+        return s3Url;
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/domain/TargetType.java
+++ b/src/main/java/org/threefour/ddip/image/domain/TargetType.java
@@ -1,0 +1,15 @@
+package org.threefour.ddip.image.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TargetType {
+    MEMBER("회원"),
+    PRODUCT("상품"),
+    CHATTING("채팅"),
+    ALARM("알림");
+
+    private final String description;
+}

--- a/src/main/java/org/threefour/ddip/image/exception/S3UploadFailedException.java
+++ b/src/main/java/org/threefour/ddip/image/exception/S3UploadFailedException.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.image.exception;
+
+public class S3UploadFailedException extends RuntimeException {
+    public S3UploadFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
+++ b/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package org.threefour.ddip.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.threefour.ddip.image.domain.Image;
+import org.threefour.ddip.image.domain.TargetType;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    List<Image> findByTargetTypeAndTargetId(TargetType targetType, Long id);
+}

--- a/src/main/java/org/threefour/ddip/image/service/ImageService.java
+++ b/src/main/java/org/threefour/ddip/image/service/ImageService.java
@@ -1,0 +1,11 @@
+package org.threefour.ddip.image.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import org.threefour.ddip.image.domain.Image;
+import org.threefour.ddip.image.domain.TargetType;
+
+import java.util.List;
+
+public interface ImageService {
+    void createImages(TargetType targetType, Long targetId, List<MultipartFile> imageRequests);
+}

--- a/src/main/java/org/threefour/ddip/image/service/ImageServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/image/service/ImageServiceImpl.java
@@ -1,0 +1,78 @@
+package org.threefour.ddip.image.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.threefour.ddip.image.domain.Image;
+import org.threefour.ddip.image.domain.TargetType;
+import org.threefour.ddip.image.exception.S3UploadFailedException;
+import org.threefour.ddip.image.repository.ImageRepository;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+    private final ImageRepository imageRepository;
+    private final S3Client s3Client;
+
+    private static final String S3_UPLOAD_FAILED_EXCEPTION_MESSAGE = "S3 업로드 과정에서 오류가 발생했습니다.";
+    private static final String TLS_HTTP_PROTOCOL = "https://";
+    private static final String S3_ADDRESS = "s3.amazonaws.com";
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String s3BucketName;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, timeout = 10)
+    public void createImages(TargetType targetType, Long targetId, List<MultipartFile> imageRequests) {
+        List<Image> images = imageRequests.stream()
+                .map(file -> createImage(file, targetType, targetId))
+                .collect(Collectors.toList());
+
+        imageRepository.saveAll(images);
+    }
+
+    private Image createImage(MultipartFile file, TargetType targetType, Long targetId) {
+        return Image.of(targetType, targetId, uploadToS3(file, targetType, targetId));
+    }
+
+    private String uploadToS3(MultipartFile file, TargetType targetType, Long productId) {
+        String originalFilename = file.getOriginalFilename();
+        long ms = System.currentTimeMillis();
+        String key = String.format("%s/%d/%s_%s", targetType.toString().toLowerCase(), productId, ms, originalFilename);
+
+        try {
+            File tempFile = convertMultipartFileToFile(file);
+            s3Client.putObject(PutObjectRequest.builder()
+                    .bucket(s3BucketName)
+                    .key(key)
+                    .build(), Paths.get(tempFile.getPath()));
+            tempFile.delete();
+        } catch (IOException ie) {
+            throw new S3UploadFailedException(S3_UPLOAD_FAILED_EXCEPTION_MESSAGE, ie);
+        }
+
+        return String.format("%s%s.%s/%s", TLS_HTTP_PROTOCOL, s3BucketName, S3_ADDRESS, key);
+    }
+
+    private File convertMultipartFileToFile(MultipartFile file) throws IOException {
+        File convertedFile
+                = new File(String.format("%s/%s", System.getProperty("java.io.tmpdir"), file.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(file.getBytes());
+        }
+        return convertedFile;
+    }
+}


### PR DESCRIPTION
## partially resolve #37

## 추가사항
- 이미지 저장 비즈니스 로직
- AWS S3에 이미지 데이터 저장
- 이미지 데이터 저장 실패 시 예외 처리
- 데이터베이스에 대상 도메인 타입, 대상 ID, S3 URL 저장

## 배포
- [x] 확인