### PR TITLE
[#44] 이미지 삭제 기능 추가

### DIFF
--- a/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
@@ -1,6 +1,8 @@
 package org.threefour.ddip.exception;
 
 public class ExceptionMessage {
+    public static final String PARSING_LONG_EXCEPTION_MESSAGE
+            = "숫자값만 Long 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String INVALID_TARGET_TYPE_EXCEPTION_MESSAGE
             = "존재하는 도메인만 TargetType으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
 }

--- a/src/main/java/org/threefour/ddip/exception/ParsingLongException.java
+++ b/src/main/java/org/threefour/ddip/exception/ParsingLongException.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.exception;
+
+public class ParsingLongException extends NumberFormatException {
+    public ParsingLongException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/controller/ImageController.java
+++ b/src/main/java/org/threefour/ddip/image/controller/ImageController.java
@@ -3,10 +3,7 @@ package org.threefour.ddip.image.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.threefour.ddip.image.domain.AddImagesRequest;
 import org.threefour.ddip.image.domain.TargetType;
@@ -29,6 +26,13 @@ public class ImageController {
             @RequestParam("images") List<MultipartFile> images) {
         TargetType targetType = FormatConverter.parseToTargetType(addImagesRequest.getTargetType());
         imageService.createImages(targetType, addImagesRequest.getTargetId(), images);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/delete/{imageId}")
+    public ResponseEntity<Void> deleteImage(@PathVariable("imageId") String id) {
+        imageService.deleteImage(FormatConverter.parseToLong(id));
 
         return ResponseEntity.status(NO_CONTENT).build();
     }

--- a/src/main/java/org/threefour/ddip/image/domain/GetImageResponse.java
+++ b/src/main/java/org/threefour/ddip/image/domain/GetImageResponse.java
@@ -1,0 +1,18 @@
+package org.threefour.ddip.image.domain;
+
+import lombok.Getter;
+
+@Getter
+public class GetImageResponse {
+    private Long id;
+    private String url;
+
+    private GetImageResponse(Long id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+
+    public static GetImageResponse from(Image image) {
+        return new GetImageResponse(image.getId(), image.getS3Url());
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/image/exception/ExceptionMessage.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.image.exception;
+
+public class ExceptionMessage {
+    public static final String S3_UPLOAD_FAILED_EXCEPTION_MESSAGE = "S3 업로드 과정에서 오류가 발생했습니다.";
+    public static final String IMAGE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 이미지를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 ID: %d";
+}

--- a/src/main/java/org/threefour/ddip/image/exception/ImageNotFoundException.java
+++ b/src/main/java/org/threefour/ddip/image/exception/ImageNotFoundException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.image.exception;
+
+import javax.persistence.EntityNotFoundException;
+
+public class ImageNotFoundException extends EntityNotFoundException {
+    public ImageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
+++ b/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
@@ -5,7 +5,10 @@ import org.threefour.ddip.image.domain.Image;
 import org.threefour.ddip.image.domain.TargetType;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
-    List<Image> findByTargetTypeAndTargetId(TargetType targetType, Long id);
+    List<Image> findByTargetTypeAndTargetIdAndDeleteYnFalse(TargetType targetType, Long id);
+
+    Optional<Image> findByIdAndDeleteYnFalse(Long id);
 }

--- a/src/main/java/org/threefour/ddip/image/service/ImageService.java
+++ b/src/main/java/org/threefour/ddip/image/service/ImageService.java
@@ -10,4 +10,6 @@ public interface ImageService {
     void createImages(TargetType targetType, Long targetId, List<MultipartFile> imageRequests);
 
     List<Image> getImages(TargetType targetType, Long targetId);
+
+    void deleteImage(Long id);
 }

--- a/src/main/java/org/threefour/ddip/util/FormatConverter.java
+++ b/src/main/java/org/threefour/ddip/util/FormatConverter.java
@@ -1,11 +1,22 @@
 package org.threefour.ddip.util;
 
 import org.threefour.ddip.exception.InvalidTargetTypeException;
+import org.threefour.ddip.exception.ParsingLongException;
 import org.threefour.ddip.image.domain.TargetType;
 
 import static org.threefour.ddip.exception.ExceptionMessage.INVALID_TARGET_TYPE_EXCEPTION_MESSAGE;
+import static org.threefour.ddip.exception.ExceptionMessage.PARSING_LONG_EXCEPTION_MESSAGE;
 
 public class FormatConverter {
+
+    public static long parseToLong(String number) {
+        try {
+            return Long.parseLong(number);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingLongException((String.format(PARSING_LONG_EXCEPTION_MESSAGE, number)));
+        }
+    }
+
     public static TargetType parseToTargetType(String targetType) {
         try {
             return TargetType.valueOf(targetType);


### PR DESCRIPTION
## resolve #44

## 추가사항
- 이미지 삭제 요청
    - 이미지 ID가 숫자 형식이 아닌 경우 예외 처리
- 이미지 조회 비즈니스 로직
    - 해당 이미지가 존재하지 않는 경우 예외 처리
- 이미지 삭제 비즈니스 로직
- 데이터베이스의 delete_yn 컬럼 업데이트를 통한 논리적 삭제
- 204 status code 반환

## 배포
- [ ] 확인