### PR TITLE
[#53] mariadb-container의 이름과 비밀번호 상수를 slave로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,15 +5,15 @@ services:
     environment:
       MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MARIADB_DATABASE: ${PROJECT_NAME}
-      MARIADB_USER: ${DB_MASTER_USER_NAME}
-      MARIADB_PASSWORD: ${DB_MASTER_USER_PASSWORD}
+      MARIADB_USER: ${DB_SLAVE_USER_NAME}
+      MARIADB_PASSWORD: ${DB_SLAVE_USER_PASSWORD}
     networks:
       - app-network
     volumes:
       - db_data:/var/lib/mysql
       - ~/my.cnf:/etc/mysql/my.cnf
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u${DB_MASTER_USER_NAME} -p${DB_MASTER_USER_PASSWORD}"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u${DB_SLAVE_USER_NAME} -p${DB_SLAVE_USER_PASSWORD}"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## partially resolve #53

## 변경사항
- 일부 DB_MASTER_USER_NAME 환경변수를 DB_SLAVE_USER_NAME으로 변경

## 배포
- [ ] 확인