### PR TITLE
[#56] 배포 서버 애플리케이션에 PROJECT_NAME 환경변수가 전달되지 않는 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       redis:
         condition: service_started
     environment:
+      PROJECT_NAME: ${PROJECT_NAME}
+      PROJECT_VERSION: ${PROJECT_VERSION}
       SPRING_DATASOURCE_MASTER_URL: jdbc:mariadb://ddip-db.c1smcu2wa2ue.us-east-2.rds.amazonaws.com:3306/${PROJECT_NAME}
       SPRING_DATASOURCE_MASTER_USERNAME: ${DB_MASTER_USER_NAME}
       SPRING_DATASOURCE_MASTER_PASSWORD: ${DB_MASTER_USER_PASSWORD}


### PR DESCRIPTION
## resolve #56

## 변경사항
- docker-compose.yml 파일에 PROJECT_NAME과 PROJECT_VERSION의 환경변수 설정 추가

## 배포
- [x] 확인