### PR TITLE
[#77] 가격정보 등록 기능 추가

### DIFF
--- a/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
@@ -7,6 +7,8 @@ public class ExceptionMessage {
             = "숫자값만 Integer 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String PARSING_SHORT_EXCEPTION_MESSAGE
             = "숫자값만 Short 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
+    public static final String PARSING_FLOAT_EXCEPTION_MESSAGE
+            = "소수값만 float 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String PARSING_TIMESTAMP_EXCEPTION_MESSAGE
             = "날짜값만 Timestamp 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String INVALID_TARGET_TYPE_EXCEPTION_MESSAGE

--- a/src/main/java/org/threefour/ddip/exception/ParsingFloatException.java
+++ b/src/main/java/org/threefour/ddip/exception/ParsingFloatException.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.exception;
+
+public class ParsingFloatException extends NumberFormatException {
+    public ParsingFloatException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/exception/ParsingTimestampException.java
+++ b/src/main/java/org/threefour/ddip/exception/ParsingTimestampException.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.exception;
+
+public class ParsingTimestampException extends InvalidValueException {
+    public ParsingTimestampException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/domain/AutoDiscountRequest.java
+++ b/src/main/java/org/threefour/ddip/product/domain/AutoDiscountRequest.java
@@ -1,0 +1,15 @@
+package org.threefour.ddip.product.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class AutoDiscountRequest {
+    private String firstDiscountDate;
+    private String priceDiscountPeriod;
+    private String priceDiscountRate;
+    private String minPrice;
+}

--- a/src/main/java/org/threefour/ddip/product/domain/RegisterProductRequest.java
+++ b/src/main/java/org/threefour/ddip/product/domain/RegisterProductRequest.java
@@ -14,4 +14,5 @@ public class RegisterProductRequest {
     private String price;
     private String title;
     private String content;
+    private AutoDiscountRequest autoDiscountRequest;
 }

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/MinPrice.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/MinPrice.java
@@ -1,0 +1,60 @@
+package org.threefour.ddip.product.priceinformation.domain;
+
+import org.threefour.ddip.product.exception.InvalidPriceException;
+import org.threefour.ddip.product.exception.PriceNoValueException;
+import org.threefour.ddip.util.FormatConverter;
+import org.threefour.ddip.util.FormatValidator;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.INVALID_MIN_PRICE_EXCEPTION_MESSAGE;
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.MIN_PRICE_NO_VALUE_EXCEPTION_MESSAGE;
+
+
+public class MinPrice {
+    private final int minPrice;
+
+    private MinPrice(int minPrice) {
+        this.minPrice = minPrice;
+    }
+
+    public static MinPrice of(String minPrice) {
+        validate(minPrice);
+        return new MinPrice(FormatConverter.parseToInt(minPrice));
+    }
+
+    private static void validate(String minPrice) {
+        checkMinPriceHasValue(minPrice);
+        checkMinPricePattern(minPrice);
+    }
+
+    private static void checkMinPriceHasValue(String minPrice) {
+        if (FormatValidator.isNoValue(minPrice)) {
+            throw new PriceNoValueException(MIN_PRICE_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private static void checkMinPricePattern(String minPrice) {
+        if (!FormatValidator.isNumberPattern(minPrice)) {
+            throw new InvalidPriceException(String.format(INVALID_MIN_PRICE_EXCEPTION_MESSAGE, minPrice));
+        }
+    }
+
+    int getValue() {
+        return minPrice;
+    }
+
+    @Converter
+    public static class MinPriceConverter implements AttributeConverter<MinPrice, Integer> {
+        @Override
+        public Integer convertToDatabaseColumn(MinPrice minPrice) {
+            return minPrice.minPrice;
+        }
+
+        @Override
+        public MinPrice convertToEntityAttribute(Integer minPrice) {
+            return minPrice == null ? null : new MinPrice(minPrice);
+        }
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/NextDiscountedAt.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/NextDiscountedAt.java
@@ -1,0 +1,68 @@
+package org.threefour.ddip.product.priceinformation.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.threefour.ddip.product.priceinformation.exception.InvalidNextDiscountedAtException;
+import org.threefour.ddip.product.priceinformation.exception.NextDiscountedAtNoValueException;
+import org.threefour.ddip.util.FormatConverter;
+import org.threefour.ddip.util.FormatValidator;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.sql.Timestamp;
+
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.INVALID_NEXT_DISCOUNTED_AT_EXCEPTION_MESSAGE;
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.NEXT_DISCOUNTED_AT_NO_VALUE_EXCEPTION_MESSAGE;
+
+public class NextDiscountedAt {
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private final Timestamp nextDiscountedAt;
+
+    private NextDiscountedAt(Timestamp nextDiscountedAt) {
+        this.nextDiscountedAt = nextDiscountedAt;
+    }
+
+    public static NextDiscountedAt of(String nextDiscountedAt) {
+        validate(nextDiscountedAt);
+        return new NextDiscountedAt(FormatConverter.parseToDate(nextDiscountedAt));
+    }
+
+    private static void validate(String nextDiscountedAt) {
+        checkDateHasValue(nextDiscountedAt);
+        checkDatePattern(nextDiscountedAt);
+    }
+
+    private static void checkDateHasValue(String nextDiscountedAt) {
+        if (FormatValidator.isNoValue(nextDiscountedAt)) {
+            throw new NextDiscountedAtNoValueException(NEXT_DISCOUNTED_AT_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private static void checkDatePattern(String nextDiscountedAt) {
+        if (!FormatValidator.isDatePattern(nextDiscountedAt)) {
+            throw new InvalidNextDiscountedAtException(
+                    String.format(INVALID_NEXT_DISCOUNTED_AT_EXCEPTION_MESSAGE, nextDiscountedAt)
+            );
+        }
+    }
+
+    @Converter
+    public static class NextDiscountedAtConverter implements AttributeConverter<NextDiscountedAt, Timestamp> {
+        @Override
+        public Timestamp convertToDatabaseColumn(NextDiscountedAt nextDiscountedAt) {
+            return nextDiscountedAt.nextDiscountedAt;
+        }
+
+        @Override
+        public NextDiscountedAt convertToEntityAttribute(Timestamp nextDiscountedAt) {
+            return nextDiscountedAt == null ? null : new NextDiscountedAt(nextDiscountedAt);
+        }
+    }
+
+    Timestamp getValue() {
+        return nextDiscountedAt;
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountPeriod.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountPeriod.java
@@ -1,0 +1,61 @@
+package org.threefour.ddip.product.priceinformation.domain;
+
+import org.threefour.ddip.product.priceinformation.exception.InvalidPriceDiscountPeriodException;
+import org.threefour.ddip.product.priceinformation.exception.PriceDiscountPeriodNoValueException;
+import org.threefour.ddip.util.FormatConverter;
+import org.threefour.ddip.util.FormatValidator;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.INVALID_PRICE_DISCOUNT_PERIOD_EXCEPTION_MESSAGE;
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.PRICE_DISCOUNT_PERIOD_NO_VALUE_EXCEPTION_MESSAGE;
+
+public class PriceDiscountPeriod {
+    private final short priceDiscountPeriod;
+
+    private PriceDiscountPeriod(short priceDiscountPeriod) {
+        this.priceDiscountPeriod = priceDiscountPeriod;
+    }
+
+    public static PriceDiscountPeriod of(String priceDiscountPeriod) {
+        validate(priceDiscountPeriod);
+        return new PriceDiscountPeriod(FormatConverter.parseToShort(priceDiscountPeriod));
+    }
+
+    private static void validate(String priceDiscountPeriod) {
+        checkPeriodHasValue(priceDiscountPeriod);
+        checkPeriodPattern(priceDiscountPeriod);
+    }
+
+    private static void checkPeriodHasValue(String priceDiscountPeriod) {
+        if (FormatValidator.isNoValue(priceDiscountPeriod)) {
+            throw new PriceDiscountPeriodNoValueException(PRICE_DISCOUNT_PERIOD_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private static void checkPeriodPattern(String priceDiscountPeriod) {
+        if (!FormatValidator.isNumberPattern(priceDiscountPeriod)) {
+            throw new InvalidPriceDiscountPeriodException(
+                    String.format(INVALID_PRICE_DISCOUNT_PERIOD_EXCEPTION_MESSAGE, priceDiscountPeriod)
+            );
+        }
+    }
+
+    @Converter
+    public static class PriceDiscountPeriodConverter implements AttributeConverter<PriceDiscountPeriod, Short> {
+        @Override
+        public Short convertToDatabaseColumn(PriceDiscountPeriod priceDiscountPeriod) {
+            return priceDiscountPeriod.priceDiscountPeriod;
+        }
+
+        @Override
+        public PriceDiscountPeriod convertToEntityAttribute(Short priceDiscountPeriod) {
+            return priceDiscountPeriod == null ? null : new PriceDiscountPeriod(priceDiscountPeriod);
+        }
+    }
+
+    short getValue() {
+        return priceDiscountPeriod;
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountRate.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountRate.java
@@ -1,0 +1,61 @@
+package org.threefour.ddip.product.priceinformation.domain;
+
+import org.threefour.ddip.product.priceinformation.exception.InvalidPriceDiscountRateException;
+import org.threefour.ddip.product.priceinformation.exception.PriceDiscountRateNoValueException;
+import org.threefour.ddip.util.FormatConverter;
+import org.threefour.ddip.util.FormatValidator;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.INVALID_PRICE_DISCOUNT_RATE_EXCEPTION_MESSAGE;
+import static org.threefour.ddip.product.priceinformation.exception.ExceptionMessage.PRICE_DISCOUNT_RATE_NO_VALUE_EXCEPTION_MESSAGE;
+
+public class PriceDiscountRate {
+    private final float priceDiscountRate;
+
+    private PriceDiscountRate(float priceDiscountRate) {
+        this.priceDiscountRate = priceDiscountRate;
+    }
+
+    public static PriceDiscountRate of(String priceDiscountPercentRate) {
+        validate(priceDiscountPercentRate);
+        return new PriceDiscountRate(FormatConverter.parseToFloat(priceDiscountPercentRate) / 100);
+    }
+
+    private static void validate(String priceDiscountPercentRate) {
+        checkRateHasValue(priceDiscountPercentRate);
+        checkRatePattern(priceDiscountPercentRate);
+    }
+
+    private static void checkRateHasValue(String priceDiscountPercentRate) {
+        if (FormatValidator.isNoValue(priceDiscountPercentRate)) {
+            throw new PriceDiscountRateNoValueException(PRICE_DISCOUNT_RATE_NO_VALUE_EXCEPTION_MESSAGE);
+        }
+    }
+
+    private static void checkRatePattern(String priceDiscountPercentRate) {
+        if (!FormatValidator.isNumberPattern(priceDiscountPercentRate)) {
+            throw new InvalidPriceDiscountRateException(
+                    String.format(INVALID_PRICE_DISCOUNT_RATE_EXCEPTION_MESSAGE, priceDiscountPercentRate)
+            );
+        }
+    }
+
+    @Converter
+    public static class PriceDiscountRateConverter implements AttributeConverter<PriceDiscountRate, Float> {
+        @Override
+        public Float convertToDatabaseColumn(PriceDiscountRate priceDiscountRate) {
+            return priceDiscountRate.priceDiscountRate;
+        }
+
+        @Override
+        public PriceDiscountRate convertToEntityAttribute(Float priceDiscountRate) {
+            return priceDiscountRate == null ? null : new PriceDiscountRate(priceDiscountRate);
+        }
+    }
+
+    byte getPercentValue() {
+        return (byte) (priceDiscountRate * 100);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceInformation.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceInformation.java
@@ -1,0 +1,98 @@
+package org.threefour.ddip.product.priceinformation.domain;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.threefour.ddip.product.domain.AutoDiscountRequest;
+import org.threefour.ddip.product.domain.Price;
+import org.threefour.ddip.product.domain.Product;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@EntityListeners(value = AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+public class PriceInformation {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Convert(converter = Price.PriceConverter.class)
+    @Column(nullable = false)
+    private Price price;
+
+    @Convert(converter = PriceDiscountPeriod.PriceDiscountPeriodConverter.class)
+    private PriceDiscountPeriod priceDiscountPeriod;
+
+    @Convert(converter = PriceDiscountRate.PriceDiscountRateConverter.class)
+    private PriceDiscountRate priceDiscountRate;
+
+    @Convert(converter = NextDiscountedAt.NextDiscountedAtConverter.class)
+    private NextDiscountedAt nextDiscountedAt;
+
+    @Convert(converter = MinPrice.MinPriceConverter.class)
+    private MinPrice minPrice;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private Timestamp createdAt;
+
+    @Builder
+    private PriceInformation(
+            Long id, Product product, Price price, PriceDiscountPeriod priceDiscountPeriod,
+            PriceDiscountRate priceDiscountRate, Timestamp createdAt,
+            NextDiscountedAt nextDiscountedAt, MinPrice minPrice
+    ) {
+        this.id = id;
+        this.product = product;
+        this.price = price;
+        this.priceDiscountPeriod = priceDiscountPeriod;
+        this.priceDiscountRate = priceDiscountRate;
+        this.createdAt = createdAt;
+        this.nextDiscountedAt = nextDiscountedAt;
+        this.minPrice = minPrice;
+    }
+
+    public static PriceInformation from(Product product, AutoDiscountRequest autoDiscountRequest) {
+        return PriceInformation.builder()
+                .product(product)
+                .price(Price.from(product))
+                .priceDiscountPeriod(PriceDiscountPeriod.of(autoDiscountRequest.getPriceDiscountPeriod()))
+                .priceDiscountRate(PriceDiscountRate.of(autoDiscountRequest.getPriceDiscountRate()))
+                .nextDiscountedAt(NextDiscountedAt.of(autoDiscountRequest.getFirstDiscountDate()))
+                .minPrice(MinPrice.of(autoDiscountRequest.getMinPrice()))
+                .build();
+    }
+
+    PriceDiscountPeriod getPriceDiscountPeriod() {
+        return priceDiscountPeriod;
+    }
+
+    PriceDiscountRate getPriceDiscountRate() {
+        return priceDiscountRate;
+    }
+
+    NextDiscountedAt getNextDiscountedAt() {
+        return nextDiscountedAt;
+    }
+
+    MinPrice getMinPrice() {
+        return minPrice;
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/ExceptionMessage.java
@@ -1,0 +1,19 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+public class ExceptionMessage {
+    public static final String PRICE_DISCOUNT_PERIOD_NO_VALUE_EXCEPTION_MESSAGE = "가격 할인 주기가 전송되지 않았습니다.";
+    public static final String INVALID_PRICE_DISCOUNT_PERIOD_EXCEPTION_MESSAGE
+            = "가격 할인 주기는 양의 정수(1 이상의 숫자)여야 합니다. 전송된 가격 할인 주기: %s";
+
+    public static final String PRICE_DISCOUNT_RATE_NO_VALUE_EXCEPTION_MESSAGE = "가격 할인율이 전송되지 않았습니다.";
+    public static final String INVALID_PRICE_DISCOUNT_RATE_EXCEPTION_MESSAGE
+            = "가격 할인율(%)은 양의 정수(1 이상의 숫자)여야 합니다. 전송된 가격 할인율: %s";
+
+    public static final String NEXT_DISCOUNTED_AT_NO_VALUE_EXCEPTION_MESSAGE = "다음 할인 날짜가 전송되지 않았습니다.";
+    public static final String INVALID_NEXT_DISCOUNTED_AT_EXCEPTION_MESSAGE
+            = "다음 할인 날짜는 날짜 형식이어야 합니다. 전송된 가격 할인율: %s";
+
+    public static final String MIN_PRICE_NO_VALUE_EXCEPTION_MESSAGE = "최소가격이 전송되지 않았습니다.";
+    public static final String INVALID_MIN_PRICE_EXCEPTION_MESSAGE
+            = "최소가격은 양의 정수(1 이상의 숫자)여야 합니다. 전송된 금액: %s";
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidNextDiscountedAtException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidNextDiscountedAtException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.InvalidValueException;
+
+public class InvalidNextDiscountedAtException extends InvalidValueException {
+    public InvalidNextDiscountedAtException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidPriceDiscountPeriodException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidPriceDiscountPeriodException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.InvalidValueException;
+
+public class InvalidPriceDiscountPeriodException extends InvalidValueException {
+    public InvalidPriceDiscountPeriodException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidPriceDiscountRateException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/InvalidPriceDiscountRateException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.InvalidValueException;
+
+public class InvalidPriceDiscountRateException extends InvalidValueException {
+    public InvalidPriceDiscountRateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/NextDiscountedAtNoValueException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/NextDiscountedAtNoValueException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.NoValueException;
+
+public class NextDiscountedAtNoValueException extends NoValueException {
+    public NextDiscountedAtNoValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/PriceDiscountPeriodNoValueException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/PriceDiscountPeriodNoValueException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.NoValueException;
+
+public class PriceDiscountPeriodNoValueException extends NoValueException {
+    public PriceDiscountPeriodNoValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/exception/PriceDiscountRateNoValueException.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/exception/PriceDiscountRateNoValueException.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.product.priceinformation.exception;
+
+import org.threefour.ddip.exception.NoValueException;
+
+public class PriceDiscountRateNoValueException extends NoValueException {
+    public PriceDiscountRateNoValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/repository/PriceInformationRepository.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/repository/PriceInformationRepository.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.product.priceinformation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.threefour.ddip.product.priceinformation.domain.PriceInformation;
+
+public interface PriceInformationRepository extends JpaRepository<PriceInformation, Long> {
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/service/PriceInformationService.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/service/PriceInformationService.java
@@ -1,0 +1,8 @@
+package org.threefour.ddip.product.priceinformation.service;
+
+import org.threefour.ddip.product.domain.AutoDiscountRequest;
+import org.threefour.ddip.product.domain.Product;
+
+public interface PriceInformationService {
+    void createPriceInformation(Product product, AutoDiscountRequest autoDiscountRequest);
+}

--- a/src/main/java/org/threefour/ddip/product/priceinformation/service/PriceInformationServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/service/PriceInformationServiceImpl.java
@@ -1,0 +1,19 @@
+package org.threefour.ddip.product.priceinformation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.threefour.ddip.product.domain.AutoDiscountRequest;
+import org.threefour.ddip.product.domain.Product;
+import org.threefour.ddip.product.priceinformation.domain.PriceInformation;
+import org.threefour.ddip.product.priceinformation.repository.PriceInformationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PriceInformationServiceImpl implements PriceInformationService {
+    private final PriceInformationRepository priceInformationRepository;
+
+    @Override
+    public void createPriceInformation(Product product, AutoDiscountRequest autoDiscountRequest) {
+        priceInformationRepository.save(PriceInformation.from(product, autoDiscountRequest));
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/service/ProductServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/product/service/ProductServiceImpl.java
@@ -8,8 +8,10 @@ import org.threefour.ddip.image.service.ImageService;
 import org.threefour.ddip.member.domain.Member;
 import org.threefour.ddip.member.repository.MemberRepository;
 import org.threefour.ddip.product.category.service.CategoryService;
+import org.threefour.ddip.product.domain.AutoDiscountRequest;
 import org.threefour.ddip.product.domain.Product;
 import org.threefour.ddip.product.domain.RegisterProductRequest;
+import org.threefour.ddip.product.priceinformation.service.PriceInformationService;
 import org.threefour.ddip.product.repository.ProductRepository;
 import org.threefour.ddip.util.FormatValidator;
 
@@ -25,6 +27,7 @@ import static org.threefour.ddip.image.domain.TargetType.PRODUCT;
 public class ProductServiceImpl implements ProductService {
     private final CategoryService categoryService;
     private final ImageService imageService;
+    private final PriceInformationService priceInformationService;
     private final ProductRepository productRepository;
     private final MemberRepository memberRepository;
 
@@ -40,6 +43,11 @@ public class ProductServiceImpl implements ProductService {
 
         if (!FormatValidator.isNoValue(images)) {
             imageService.createImages(PRODUCT, product.getId(), images);
+        }
+
+        AutoDiscountRequest autoDiscountRequest = registerProductRequest.getAutoDiscountRequest();
+        if (autoDiscountRequest != null) {
+            priceInformationService.createPriceInformation(product, autoDiscountRequest);
         }
 
         return product.getId();

--- a/src/main/java/org/threefour/ddip/util/EntityConstant.java
+++ b/src/main/java/org/threefour/ddip/util/EntityConstant.java
@@ -2,4 +2,5 @@ package org.threefour.ddip.util;
 
 public class EntityConstant {
     public static final String BOOLEAN_DEFAULT_FALSE = "boolean default false";
+    static final String DATE_PATTERN = "yyyy-MM-dd";
 }

--- a/src/main/java/org/threefour/ddip/util/FormatConverter.java
+++ b/src/main/java/org/threefour/ddip/util/FormatConverter.java
@@ -1,12 +1,14 @@
 package org.threefour.ddip.util;
 
-import org.threefour.ddip.exception.InvalidTargetTypeException;
-import org.threefour.ddip.exception.ParsingIntegerException;
-import org.threefour.ddip.exception.ParsingLongException;
-import org.threefour.ddip.exception.ParsingShortException;
+import org.threefour.ddip.exception.*;
 import org.threefour.ddip.image.domain.TargetType;
 
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
 import static org.threefour.ddip.exception.ExceptionMessage.*;
+import static org.threefour.ddip.util.EntityConstant.DATE_PATTERN;
 
 public class FormatConverter {
     public static long parseToLong(String number) {
@@ -33,11 +35,29 @@ public class FormatConverter {
         }
     }
 
+    public static float parseToFloat(String primeNumber) {
+        try {
+            return Float.parseFloat(primeNumber);
+        } catch (NumberFormatException nfe) {
+            throw new ParsingFloatException((String.format(PARSING_FLOAT_EXCEPTION_MESSAGE, primeNumber)));
+        }
+    }
+
     public static TargetType parseToTargetType(String targetType) {
         try {
             return TargetType.valueOf(targetType);
         } catch (IllegalArgumentException iae) {
             throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
+        }
+    }
+
+    public static Timestamp parseToDate(String date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_PATTERN);
+        dateFormat.setLenient(false);
+        try {
+            return new Timestamp(dateFormat.parse(date).getTime());
+        } catch (ParseException e) {
+            throw new ParsingTimestampException(String.format(PARSING_TIMESTAMP_EXCEPTION_MESSAGE, date));
         }
     }
 }

--- a/src/main/java/org/threefour/ddip/util/FormatValidator.java
+++ b/src/main/java/org/threefour/ddip/util/FormatValidator.java
@@ -1,7 +1,10 @@
 package org.threefour.ddip.util;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
+import static org.threefour.ddip.util.EntityConstant.DATE_PATTERN;
 import static org.threefour.ddip.util.RegularExpressionConstant.POSITIVE_INTEGER_PATTERN;
 
 public class FormatValidator {
@@ -15,5 +18,16 @@ public class FormatValidator {
 
     public static boolean isNumberPattern(String value) {
         return value.matches(POSITIVE_INTEGER_PATTERN);
+    }
+
+    public static boolean isDatePattern(String date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_PATTERN);
+        dateFormat.setLenient(false);
+        try {
+            dateFormat.parse(date);
+            return true;
+        } catch (ParseException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## resolve #77

## 추가사항
### 가격 정보
- 상품 등록 시 가격 정보 등록 비즈니르 로직
- 데이터베이스에 가격 정보 저장

### 가격 할인 주기
- 가격 할인 주기 정보를 담고 있는 PriceDiscountPeriod 속성의 포장 객체
    - 무결성을 유지하기 위한 유효성 검사
        - 예외처리를 위한 커스텀 예외
            - 추상 예외 클래스 NoValueException 클래스를 상속하는 PriceDiscountPeriodNoValueException 클래스
            - 추상 예외 클래스 InvalidValueException을 상속하는 InvalidPriceDiscountPeriodException 클래스
        - String에서 int 타입으로 변환 시 예외 처리
            - NumberFormatException 클래스를 상속하는 ParsingIntegerException 클래스
    - 무결성과 보안을 유지하기 위해 getter의 접근 제한자를 default로 설정
    - 내부 클래스 PriceDiscountPeriodConverter를 통한 엔티티 속성 매핑

### 가격 할인율
- 가격 할인율 정보를 담고 있는 PriceDiscountRate 속성의 포장 객체
    - 무결성을 유지하기 위한 유효성 검사
        - 예외처리를 위한 커스텀 예외
            - 추상 예외 클래스 NoValueException 클래스를 상속하는 PriceDiscountRateNoValueException 클래스
            - 추상 예외 클래스 InvalidValueException을 상속하는 InvalidPriceDiscountRateException 클래스
        - String에서 float 타입으로 변환 시 예외 처리
            - NumberFormatException 클래스를 상속하는 ParsingFloatException 클래스
    - 무결성과 보안을 유지하기 위해 getter의 접근 제한자를 default로 설정
    - 내부 클래스 PriceDiscountRateConverter를 통한 엔티티 속성 매핑

### 다음 할인 날짜
- 다음 할인 날짜 정보를 담고 있는 NextDiscountedAt 속성의 포장 객체
    - 무결성을 유지하기 위한 유효성 검사
        - 예외처리를 위한 커스텀 예외
            - 추상 예외 클래스 NoValueException 클래스를 상속하는 NextDiscountedAtNoValueException 클래스
            - 추상 예외 클래스 InvalidValueException을 상속하는 InvalidNextDiscountedAtException 클래스
        - 날짜 형식에 대한 유효성 검사
        - String에서 Timestamp 타입으로 변환 시 예외 처리
            - InvalidValueException 클래스를 상속하는 ParsingTimestampException 클래스
    - 무결성과 보안을 유지하기 위해 getter의 접근 제한자를 default로 설정
    - 내부 클래스 NextDiscountedAtConverter를 통한 엔티티 속성 매핑

### 최저 가격
- 최저 가격 정보를 담고 있는 MinPrice 속성의 포장 객체
    - 무결성을 유지하기 위한 유효성 검사
        - 예외처리를 위한 커스텀 예외
            - 추상 예외 클래스 NoValueException 클래스를 상속하는 PriceNoValueException 클래스
            - 추상 예외 클래스 InvalidValueException을 상속하는 InvalidPriceException 클래스
        - String에서 int 타입으로 변환 시 예외 처리
            - NumberFormatException 클래스를 상속하는 ParsingIntegerException 클래스
    - 무결성과 보안을 유지하기 위해 getter의 접근 제한자를 default로 설정
    - 내부 클래스 MinPriceConverter를 통한 엔티티 속성 매핑

## 배포
- [x] 확인