### PR TITLE
[#83] 상품 목록 조회 기능 추가, 페이지네이션 적용

### DIFF
--- a/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/exception/ExceptionMessage.java
@@ -11,6 +11,8 @@ public class ExceptionMessage {
             = "소수값만 float 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String PARSING_TIMESTAMP_EXCEPTION_MESSAGE
             = "날짜값만 Timestamp 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
+    public static final String PARSING_BOOLEAN_EXCEPTION_MESSAGE
+            = "논리형 값만 Boolean 타입으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
     public static final String INVALID_TARGET_TYPE_EXCEPTION_MESSAGE
             = "존재하는 도메인만 TargetType으로 변환할 수 있습니다. 현재 변환 대상 값: %s";
 }

--- a/src/main/java/org/threefour/ddip/exception/ParsingBooleanException.java
+++ b/src/main/java/org/threefour/ddip/exception/ParsingBooleanException.java
@@ -1,0 +1,7 @@
+package org.threefour.ddip.exception;
+
+public class ParsingBooleanException extends IllegalArgumentException {
+    public ParsingBooleanException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/domain/RepresentativeImagesRequest.java
+++ b/src/main/java/org/threefour/ddip/image/domain/RepresentativeImagesRequest.java
@@ -1,0 +1,36 @@
+package org.threefour.ddip.image.domain;
+
+import org.threefour.ddip.product.domain.Product;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.threefour.ddip.image.domain.TargetType.PRODUCT;
+
+public class RepresentativeImagesRequest {
+    private TargetType targetType;
+    private List<Long> targetIds;
+
+    private RepresentativeImagesRequest(TargetType targetType, List<Long> targetIds) {
+        this.targetType = targetType;
+        this.targetIds = targetIds;
+    }
+
+    public static RepresentativeImagesRequest from(List<Product> products) {
+        List<Long> targetIds = products.stream().map(Product::getId).collect(Collectors.toList());
+
+        return new RepresentativeImagesRequest(PRODUCT, targetIds);
+    }
+
+    public TargetType getTargetType() {
+        return targetType;
+    }
+
+    public Long get(int index) {
+        return targetIds.get(index);
+    }
+
+    public int size() {
+        return targetIds.size();
+    }
+}

--- a/src/main/java/org/threefour/ddip/image/exception/ExceptionMessage.java
+++ b/src/main/java/org/threefour/ddip/image/exception/ExceptionMessage.java
@@ -4,4 +4,6 @@ public class ExceptionMessage {
     public static final String S3_UPLOAD_FAILED_EXCEPTION_MESSAGE = "S3 업로드 과정에서 오류가 발생했습니다.";
     public static final String IMAGE_NOT_FOUND_EXCEPTION_MESSAGE
             = "해당하는 이미지를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 ID: %d";
+    public static final String TARGET_IMAGE_NOT_FOUND_EXCEPTION_MESSAGE
+            = "해당하는 이미지를 찾을 수 없습니다. 다시 시도해 주세요. 전송된 대상 타입: %s, 전송된 대상 ID: %d";
 }

--- a/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
+++ b/src/main/java/org/threefour/ddip/image/repository/ImageRepository.java
@@ -11,4 +11,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByTargetTypeAndTargetIdAndDeleteYnFalse(TargetType targetType, Long id);
 
     Optional<Image> findByIdAndDeleteYnFalse(Long id);
+
+    Optional<Image> findFirstByTargetTypeAndTargetIdAndDeleteYnFalseOrderByCreatedAt(
+            TargetType targetType, Long targetId
+    );
 }

--- a/src/main/java/org/threefour/ddip/image/service/ImageService.java
+++ b/src/main/java/org/threefour/ddip/image/service/ImageService.java
@@ -2,6 +2,7 @@ package org.threefour.ddip.image.service;
 
 import org.springframework.web.multipart.MultipartFile;
 import org.threefour.ddip.image.domain.Image;
+import org.threefour.ddip.image.domain.RepresentativeImagesRequest;
 import org.threefour.ddip.image.domain.TargetType;
 
 import java.util.List;
@@ -10,6 +11,8 @@ public interface ImageService {
     void createImages(TargetType targetType, Long targetId, List<MultipartFile> imageRequests);
 
     List<Image> getImages(TargetType targetType, Long targetId);
+
+    List<Image> getRepresentativeImages(RepresentativeImagesRequest representativeImagesRequest);
 
     void deleteImage(Long id);
 }

--- a/src/main/java/org/threefour/ddip/product/controller/ProductController.java
+++ b/src/main/java/org/threefour/ddip/product/controller/ProductController.java
@@ -1,23 +1,32 @@
 package org.threefour.ddip.product.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
+import org.threefour.ddip.image.domain.Image;
+import org.threefour.ddip.image.domain.RepresentativeImagesRequest;
 import org.threefour.ddip.image.service.ImageService;
 import org.threefour.ddip.product.category.domain.Category;
 import org.threefour.ddip.product.category.domain.GetCategoriesResponse;
 import org.threefour.ddip.product.category.service.CategoryService;
 import org.threefour.ddip.product.domain.GetProductResponse;
+import org.threefour.ddip.product.domain.GetProductsResponse;
+import org.threefour.ddip.product.domain.Product;
 import org.threefour.ddip.product.domain.RegisterProductRequest;
 import org.threefour.ddip.product.service.ProductService;
 import org.threefour.ddip.util.FormatConverter;
 import org.threefour.ddip.util.FormatValidator;
 
+import javax.servlet.http.HttpSession;
 import java.util.List;
 
 import static org.threefour.ddip.image.domain.TargetType.PRODUCT;
+import static org.threefour.ddip.util.PagingConstant.*;
 
 @Controller
 @RequestMapping("/product")
@@ -41,6 +50,43 @@ public class ProductController {
     ) {
         Long productId = productService.createProduct(registerProductRequest, images);
         return String.format("redirect:details?id=%d", productId);
+    }
+
+
+    @GetMapping("/list")
+    public ModelAndView getProducts(
+            @RequestParam(defaultValue = TRUE) String paged,
+            @RequestParam(defaultValue = MINUS_ONE) String pageNumber,
+            @RequestParam(defaultValue = NINE) String size,
+            @RequestParam(defaultValue = ORDER_BY_CREATED_AT_DESCENDING) String sort,
+            @RequestParam(defaultValue = ZERO) String categoryId,
+            HttpSession httpSession
+    ) {
+        if (pageNumber.equals(MINUS_ONE)) {
+            httpSession.setAttribute("categoryId", categoryId);
+            pageNumber = ZERO;
+        }
+        if (categoryId.equals(ZERO)) {
+            categoryId = (String) httpSession.getAttribute("categoryId");
+        }
+        if (FormatValidator.isNoValue(categoryId)) {
+            categoryId = ZERO;
+        }
+
+        Pageable pageable = FormatConverter.parseToBoolean(paged)
+                ? PageRequest.of(
+                FormatConverter.parseToInt(pageNumber),
+                FormatConverter.parseToInt(size),
+                FormatConverter.parseSortString(sort)
+        )
+                : Pageable.unpaged();
+
+        Page<Product> products
+                = productService.getProducts(pageable, FormatConverter.parseToShort(categoryId));
+        List<Image> representativeImages
+                = imageService.getRepresentativeImages(RepresentativeImagesRequest.from(products.getContent()));
+
+        return new ModelAndView("product/list", "products", GetProductsResponse.from(products, representativeImages));
     }
 
     @GetMapping("/details")

--- a/src/main/java/org/threefour/ddip/product/domain/GetProductResponse.java
+++ b/src/main/java/org/threefour/ddip/product/domain/GetProductResponse.java
@@ -53,4 +53,8 @@ public class GetProductResponse {
                 .imageResponses(images.stream().map(GetImageResponse::from).collect(Collectors.toList()))
                 .build();
     }
+
+    public GetImageResponse getImage(int index) {
+        return imageResponses.get(index);
+    }
 }

--- a/src/main/java/org/threefour/ddip/product/domain/GetProductsResponse.java
+++ b/src/main/java/org/threefour/ddip/product/domain/GetProductsResponse.java
@@ -1,0 +1,34 @@
+package org.threefour.ddip.product.domain;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.threefour.ddip.image.domain.Image;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class GetProductsResponse {
+    private List<GetProductResponse> getProductResponses;
+    private PageInformation pageInformation;
+
+    private GetProductsResponse(List<GetProductResponse> getProductResponses, PageInformation pageInformation) {
+        this.getProductResponses = getProductResponses;
+        this.pageInformation = pageInformation;
+    }
+
+    public static GetProductsResponse from(Page<Product> pagedProducts, List<Image> images) {
+
+        List<Product> products = pagedProducts.getContent();
+        List<GetProductResponse> getProductResponses = new ArrayList<>();
+        for (int i = 0; i < products.size(); i++) {
+            getProductResponses.add(GetProductResponse.from(products.get(i), List.of(images.get(i))));
+        }
+
+        return new GetProductsResponse(getProductResponses, PageInformation.from(pagedProducts));
+    }
+
+    public GetProductResponse get(int index) {
+        return getProductResponses.get(index);
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/domain/PageInformation.java
+++ b/src/main/java/org/threefour/ddip/product/domain/PageInformation.java
@@ -1,0 +1,38 @@
+package org.threefour.ddip.product.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PageInformation {
+    private Long totalElements;
+    private int totalPages;
+    private int size;
+    private int pageNumber;
+    private boolean isFirst;
+    private boolean isLast;
+
+    @Builder
+    private PageInformation(
+            Long totalElements, int totalPages, int size, int pageNumber, boolean isFirst, boolean isLast
+    ) {
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.size = size;
+        this.pageNumber = pageNumber;
+        this.isFirst = isFirst;
+        this.isLast = isLast;
+    }
+
+    public static PageInformation from(Page<Product> pagedProducts) {
+        return PageInformation.builder()
+                .totalElements(pagedProducts.getTotalElements())
+                .totalPages(pagedProducts.getTotalPages())
+                .size(pagedProducts.getSize())
+                .pageNumber(pagedProducts.getNumber())
+                .isFirst(pagedProducts.isFirst())
+                .isLast(pagedProducts.isLast())
+                .build();
+    }
+}

--- a/src/main/java/org/threefour/ddip/product/repository/ProductRepository.java
+++ b/src/main/java/org/threefour/ddip/product/repository/ProductRepository.java
@@ -1,10 +1,19 @@
 package org.threefour.ddip.product.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.threefour.ddip.product.domain.Product;
 
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findByIdAndDeleteYnFalse(Long productId);
+
+    Page<Product> findByDeleteYnFalse(Pageable pageable);
+
+    @Query("SELECT p FROM Product p JOIN p.productCategories pc WHERE pc.category.id = :categoryId AND p.deleteYn = false")
+    Page<Product> findByCategoryIdAndDeleteYnFalse(@Param("categoryId") Short categoryId, Pageable pageable);
 }

--- a/src/main/java/org/threefour/ddip/product/service/ProductService.java
+++ b/src/main/java/org/threefour/ddip/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package org.threefour.ddip.product.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import org.threefour.ddip.product.domain.Product;
 import org.threefour.ddip.product.domain.RegisterProductRequest;
@@ -10,4 +12,6 @@ public interface ProductService {
     Long createProduct(RegisterProductRequest registerProductRequest, List<MultipartFile> images);
 
     Product getProduct(Long productId);
+
+    Page<Product> getProducts(Pageable pageable, Short categoryId);
 }

--- a/src/main/java/org/threefour/ddip/product/service/ProductServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/product/service/ProductServiceImpl.java
@@ -1,6 +1,8 @@
 package org.threefour.ddip.product.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,10 +56,20 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    @Transactional(isolation = READ_UNCOMMITTED, readOnly = true, timeout = 10)
+    @Transactional(isolation = READ_COMMITTED, readOnly = true, timeout = 10)
     public Product getProduct(Long productId) {
         return productRepository.findByIdAndDeleteYnFalse(productId).orElseThrow(
                 () -> new ProductNotFoundException(String.format(PRODUCT_NOT_FOUND_EXCEPTION_MESSAGE, productId))
         );
+    }
+
+    @Override
+    @Transactional(isolation = READ_UNCOMMITTED, readOnly = true, timeout = 20)
+    public Page<Product> getProducts(Pageable pageable, Short categoryId) {
+        if (categoryId == 0) {
+            return productRepository.findByDeleteYnFalse(pageable);
+        }
+
+        return productRepository.findByCategoryIdAndDeleteYnFalse(categoryId, pageable);
     }
 }

--- a/src/main/java/org/threefour/ddip/util/FormatConverter.java
+++ b/src/main/java/org/threefour/ddip/util/FormatConverter.java
@@ -1,5 +1,6 @@
 package org.threefour.ddip.util;
 
+import org.springframework.data.domain.Sort;
 import org.threefour.ddip.exception.*;
 import org.threefour.ddip.image.domain.TargetType;
 
@@ -11,6 +12,10 @@ import static org.threefour.ddip.exception.ExceptionMessage.*;
 import static org.threefour.ddip.util.EntityConstant.DATE_PATTERN;
 
 public class FormatConverter {
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+
+
     public static long parseToLong(String number) {
         try {
             return Long.parseLong(number);
@@ -43,14 +48,6 @@ public class FormatConverter {
         }
     }
 
-    public static TargetType parseToTargetType(String targetType) {
-        try {
-            return TargetType.valueOf(targetType);
-        } catch (IllegalArgumentException iae) {
-            throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
-        }
-    }
-
     public static Timestamp parseToDate(String date) {
         SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_PATTERN);
         dateFormat.setLenient(false);
@@ -59,5 +56,26 @@ public class FormatConverter {
         } catch (ParseException e) {
             throw new ParsingTimestampException(String.format(PARSING_TIMESTAMP_EXCEPTION_MESSAGE, date));
         }
+    }
+
+    public static boolean parseToBoolean(String value) {
+        if (!value.equals(TRUE) && !value.equals(FALSE)) {
+            throw new ParsingBooleanException((String.format(PARSING_BOOLEAN_EXCEPTION_MESSAGE, value)));
+        }
+
+        return Boolean.parseBoolean(value);
+    }
+
+    public static TargetType parseToTargetType(String targetType) {
+        try {
+            return TargetType.valueOf(targetType);
+        } catch (IllegalArgumentException iae) {
+            throw new InvalidTargetTypeException(String.format(INVALID_TARGET_TYPE_EXCEPTION_MESSAGE, targetType));
+        }
+    }
+
+    public static Sort parseSortString(String sort) {
+        String[] parts = sort.split(",");
+        return Sort.by(Sort.Direction.fromString(parts[1]), parts[0]);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,12 +18,12 @@ spring:
   datasource:
     master:
       driver-class-name: org.mariadb.jdbc.Driver
-      jdbc-url: jdbc:mariadb://ddip-db.c12qq8qq0tns.ap-northeast-2.rds.amazonaws.com:3306/${PROJECT_NAME}?serverTimezone=UTC&characterEncoding=UTF-8
+      jdbc-url: jdbc:mariadb://${PROJECT_NAME}-db.c12qq8qq0tns.ap-northeast-2.rds.amazonaws.com:3306/${PROJECT_NAME}?serverTimezone=UTC&characterEncoding=UTF-8&useUnicode=true
       username: ${DB_MASTER_USER_NAME}
       password: ${DB_MASTER_USER_PASSWORD}
     slave:
       driver-class-name: org.mariadb.jdbc.Driver
-      jdbc-url: jdbc:mariadb://mariadb-container:3306/${PROJECT_NAME}?serverTimezone=UTC&characterEncoding=UTF-8
+      jdbc-url: jdbc:mariadb://mariadb-container:3306/${PROJECT_NAME}?serverTimezone=UTC&characterEncoding=UTF-8&useUnicode=true
       username: ${DB_SLAVE_USER_NAME}
       password: ${DB_SLAVE_USER_PASSWORD}
   jpa:

--- a/src/main/resources/templates/product/details.html
+++ b/src/main/resources/templates/product/details.html
@@ -117,9 +117,9 @@
             <div class="col-lg-12">
                 <div class="breadcrumb__links">
                     <a href="./index.html"><i class="fa fa-home"></i> Home</a>
-                    <a th:href="@{/product/category(categoryId=${product.getCategoriesResponse.getCategoryResponses.get(0).id})}"
+                    <a th:href="@{/product/list(categoryId=${product.getCategoriesResponse.getCategoryResponses.get(0).id})}"
                        th:text="${product.getCategoriesResponse.getCategoryResponses.get(0).name.description}">Category Level 1</a>
-                    <a th:href="@{/product/category(categoryId=${product.getCategoriesResponse.getCategoryResponses.get(1).id})}"
+                    <a th:href="@{/product/list(categoryId=${product.getCategoriesResponse.getCategoryResponses.get(1).id})}"
                        th:text="${product.getCategoriesResponse.getCategoryResponses.get(1).name.description}">Category Level 2</a>
                     <span th:text="${product.getCategoriesResponse.getCategoryResponses.get(2).name.description}">Category Level 3</span>
                 </div>

--- a/src/main/resources/templates/product/registration.html
+++ b/src/main/resources/templates/product/registration.html
@@ -259,6 +259,7 @@
                                         <input class="form-control" id="image-upload" type="file" name="images"
                                                multiple accept="image/*" onchange="previewImages()"/>
                                     </div>
+                                    <small style="color: gray;">첫 번째 이미지가 상품 목록에 게시됩니다.</small>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## partially resolve #83

## 추가/변경사항

### 상품 목록
- 상품 목록 조회 요청
- 상품 목록 조회 비즈니스 로직
    - 페이지네이션 적용
    - 전체 목록 조회
    - 카테고리 별 조회
- 데이터 반환
    - 상품 목록
        - 각 상품 정보
        - 각 상품의 대표 이미지
    - 페이지네이션 정보
        - 총 데이터 수
        - 총 페이지 수
        - 페이지 크기
        - 페이지 번호
        - 첫 번째 페이지인지 여부
        - 마지막 페이지인지 여부
- 상품 목록 페이지
    - 상품 목록
        - 각 상품 정보
        - 각 상품의 대표 이미지
    - 페이지네이션 적용

### 페이징
- 페이지 적용 여부
        - String에서 boolean 타입으로 변환 시 예외 처리
            - IllegalArgumentException 클래스를 상속하는 ParsingBooleanException 클래스
- 페이지 번호
        - String에서 int 타입으로 변환 시 예외 처리
            - NumberFormatException 클래스를 상속하는 ParsingIntegerException 클래스
- 페이지 크기
        - String에서 int 타입으로 변환 시 예외 처리
            - NumberFormatException 클래스를 상속하는 ParsingIntegerException 클래스
- 정렬 기준
    - Sort 타입으로 변환

### 카테고리
- 목록 접속 시 현재 카테고리 정보 세션에 저장
- 페이지 넘김 시 세션에 저장된 카테고리 정보 활용

### 이미지
- 대표 이미지 목록 조회 비즈니스 로직
    - 트랜잭션 적용
        - 격리 수준: REPEATABLE_READ(동일 테이블에 대한 반복 조회)
        - 읽기 전용
        - 데이터베이스 최대 응답시간: 20초
    - TargetType과 targetId를 통해 조회
    - 해당하는 이미지가 없을 시 EntityNotFoundException 클래스를 상속하는 ImageNotFoundException 클래스를 통한 예외처리

### 애플리케이션
- 데이터베이스 인코딩 설정 변경

## 배포
- [x] 확인