### PR TITLE
[#93] 상품 도메인에 Redis Cache 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,10 @@ dependencies {
 
     // data
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
-    runtimeOnly 'org.springframework.boot:spring-boot-starter-data-redis:2.7.12'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.7.12'
     testRuntimeOnly 'com.h2database:h2:2.1.214'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.12'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.15.2'
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security:2.7.8'

--- a/src/main/java/org/threefour/ddip/audit/BaseEntity.java
+++ b/src/main/java/org/threefour/ddip/audit/BaseEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @EntityListeners(value = AuditingEntityListener.class)
 @MappedSuperclass
@@ -22,10 +22,10 @@ public abstract class BaseEntity {
     @Column(nullable = false, updatable = false)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private Timestamp modifiedAt;
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/org/threefour/ddip/configuration/CacheConfig.java
+++ b/src/main/java/org/threefour/ddip/configuration/CacheConfig.java
@@ -1,0 +1,80 @@
+package org.threefour.ddip.configuration;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.threefour.ddip.hibernate.HibernateCollectionMixIn;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static org.springframework.data.redis.cache.RedisCacheConfiguration.defaultCacheConfig;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new Hibernate5Module());
+        mapper.registerModule(new JavaTimeModule());
+
+        mapper.addMixIn(Collection.class, HibernateCollectionMixIn.class);
+
+        return mapper;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .entryTtl(defaultCacheConfig().entryTtl(Duration.ofMinutes(30)).getTtl());
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+}

--- a/src/main/java/org/threefour/ddip/hibernate/HibernateCollectionIdResolver.java
+++ b/src/main/java/org/threefour/ddip/hibernate/HibernateCollectionIdResolver.java
@@ -1,0 +1,65 @@
+package org.threefour.ddip.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import lombok.NoArgsConstructor;
+import org.hibernate.collection.internal.*;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.*;
+
+@NoArgsConstructor
+public class HibernateCollectionIdResolver extends TypeIdResolverBase {
+
+    @Override
+    public String idFromValue(Object value) {
+        if (value instanceof PersistentArrayHolder) {
+            return Array.class.getName();
+        }
+
+        if (value instanceof PersistentBag || value instanceof PersistentIdentifierBag
+                || value instanceof PersistentList) {
+            return List.class.getName();
+        }
+
+        if (value instanceof PersistentSortedMap) {
+            return TreeMap.class.getName();
+        }
+
+        if (value instanceof PersistentSortedSet) {
+            return TreeSet.class.getName();
+        }
+
+        if (value instanceof PersistentMap) {
+            return HashMap.class.getName();
+        }
+
+        if (value instanceof PersistentSet) {
+            return HashSet.class.getName();
+        }
+
+        return value.getClass().getName();
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+        return idFromValue(value);
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext ctx, String id) throws IOException {
+        try {
+            return ctx.getConfig().constructType(Class.forName(id));
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.CLASS;
+    }
+}

--- a/src/main/java/org/threefour/ddip/hibernate/HibernateCollectionMixIn.java
+++ b/src/main/java/org/threefour/ddip/hibernate/HibernateCollectionMixIn.java
@@ -1,0 +1,9 @@
+package org.threefour.ddip.hibernate;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonTypeIdResolver(value = HibernateCollectionIdResolver.class)
+public class HibernateCollectionMixIn {
+}

--- a/src/main/java/org/threefour/ddip/product/category/controller/CategoryController.java
+++ b/src/main/java/org/threefour/ddip/product/category/controller/CategoryController.java
@@ -31,7 +31,7 @@ public class CategoryController {
     @GetMapping()
     public ResponseEntity<GetCategoriesResponse> getCategories(@RequestParam("parentCategoryId") String parentCategoryId) {
         Short parsedParentCategoryId = null;
-        if (FormatValidator.hasValue(parentCategoryId) && FormatValidator.isNumberPattern(parentCategoryId)) {
+        if (FormatValidator.hasValue(parentCategoryId) && FormatValidator.isPositiveNumberPattern(parentCategoryId)) {
             parsedParentCategoryId = FormatConverter.parseToShort(parentCategoryId);
         }
 

--- a/src/main/java/org/threefour/ddip/product/category/domain/Category.java
+++ b/src/main/java/org/threefour/ddip/product/category/domain/Category.java
@@ -1,9 +1,11 @@
 package org.threefour.ddip.product.category.domain;
 
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 import org.threefour.ddip.audit.BaseEntity;
 
 import javax.persistence.*;
+import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -23,6 +25,9 @@ public class Category extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "parent_category_id")
     private Category parentCategory;
+
+    @OneToMany(mappedBy = "category")
+    private List<ProductCategory> productCategories;
 
     @Column(nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
     private boolean deleteYn;
@@ -44,15 +49,20 @@ public class Category extends BaseEntity {
         return new Category(registerCategoryRequest.getCategoryName(), parentCategory);
     }
 
-    Short getId() {
+    public Short getId() {
         return id;
     }
 
-    CategoryName getName() {
+    public CategoryName getName() {
         return name;
     }
 
     public void delete() {
         deleteYn = true;
+    }
+
+    @PostLoad
+    private void init() {
+        Hibernate.initialize(productCategories);
     }
 }

--- a/src/main/java/org/threefour/ddip/product/category/domain/ProductCategory.java
+++ b/src/main/java/org/threefour/ddip/product/category/domain/ProductCategory.java
@@ -1,6 +1,8 @@
 package org.threefour.ddip.product.category.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.threefour.ddip.audit.BaseEntity;
 import org.threefour.ddip.product.domain.Product;
@@ -23,6 +25,7 @@ public class ProductCategory extends BaseEntity {
     @Id
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "product_id", referencedColumnName = "id", foreignKey = @ForeignKey(name = "FK_product_id"))
+    @JsonBackReference
     private Product product;
 
     private ProductCategory(Category category, Product product) {
@@ -34,7 +37,12 @@ public class ProductCategory extends BaseEntity {
         return new ProductCategory(category, product);
     }
 
-    Category getCategory() {
+    public Category getCategory() {
         return category;
+    }
+
+    @PostLoad
+    public void init() {
+        Hibernate.initialize(category);
     }
 }

--- a/src/main/java/org/threefour/ddip/product/controller/ProductController.java
+++ b/src/main/java/org/threefour/ddip/product/controller/ProductController.java
@@ -44,7 +44,7 @@ public class ProductController {
     @PostMapping("/registration-confirm")
     public String registerProduct(
             @ModelAttribute RegisterProductRequest registerProductRequest,
-            @RequestParam("images") List<MultipartFile> images
+            @RequestParam("images") @RequestPart List<MultipartFile> images
     ) {
         Long productId = productService.createProduct(registerProductRequest, images);
         return String.format("redirect:details?id=%d", productId);
@@ -89,27 +89,29 @@ public class ProductController {
 
     @GetMapping("/details")
     public ModelAndView getProduct(@RequestParam String id) {
-        if (!FormatValidator.hasValue(id) || !FormatValidator.isNumberPattern(id)) {
+        if (!FormatValidator.hasValue(id) || !FormatValidator.isPositiveNumberPattern(id)) {
             return new ModelAndView("redirect:list");
         }
         Long parsedId = FormatConverter.parseToLong(id);
 
         return new ModelAndView(
                 "product/details", "product",
-                GetProductResponse.from(productService.getProduct(parsedId), imageService.getImages(PRODUCT, parsedId))
+                GetProductResponse.fromDetails(
+                        productService.getProduct(parsedId, true), imageService.getImages(PRODUCT, parsedId)
+                )
         );
     }
 
     @GetMapping("/modification-form")
     public ModelAndView getModificationForm(@RequestParam String id) {
-        if (!FormatValidator.hasValue(id) || !FormatValidator.isNumberPattern(id)) {
+        if (!FormatValidator.hasValue(id) || !FormatValidator.isPositiveNumberPattern(id)) {
             return new ModelAndView("redirect:list");
         }
         ModelAndView modelAndView = new ModelAndView();
         Long parsedId = FormatConverter.parseToLong(id);
         modelAndView.addObject(
                 "product",
-                GetProductResponse.from(productService.getProduct(parsedId), imageService.getImages(PRODUCT, parsedId))
+                GetProductResponse.from(productService.getProduct(parsedId, false), imageService.getImages(PRODUCT, parsedId))
         );
         modelAndView.addObject("categories", GetCategoriesResponse.from(categoryService.getCategories(null)));
         modelAndView.setViewName("product/modification");

--- a/src/main/java/org/threefour/ddip/product/domain/GetProductResponse.java
+++ b/src/main/java/org/threefour/ddip/product/domain/GetProductResponse.java
@@ -54,6 +54,19 @@ public class GetProductResponse {
                 .build();
     }
 
+    public static Object fromDetails(Product product, List<Image> images) {
+        return GetProductResponse.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .price(product.getPrice().getValue())
+                .title(product.getTitle())
+                .content(product.getContent())
+                .seller(product.getSeller())
+                .getCategoriesResponse(GetCategoriesResponse.fromProduct(product.getProductCategories()))
+                .imageResponses(images.stream().map(GetImageResponse::from).collect(Collectors.toList()))
+                .build();
+    }
+
     public GetImageResponse getImage(int index) {
         return imageResponses.get(index);
     }

--- a/src/main/java/org/threefour/ddip/product/domain/Price.java
+++ b/src/main/java/org/threefour/ddip/product/domain/Price.java
@@ -1,5 +1,7 @@
 package org.threefour.ddip.product.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.threefour.ddip.product.exception.InvalidPriceException;
 import org.threefour.ddip.product.exception.PriceNoValueException;
 import org.threefour.ddip.util.FormatConverter;
@@ -7,18 +9,20 @@ import org.threefour.ddip.util.FormatValidator;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
+import java.io.Serializable;
 
 import static org.threefour.ddip.product.exception.ExceptionMessage.INVALID_PRICE_EXCEPTION_MESSAGE;
 import static org.threefour.ddip.product.exception.ExceptionMessage.PRICE_NO_VALUE_EXCEPTION_MESSAGE;
 
-public class Price {
+public class Price implements Serializable {
     private final int price;
 
     private Price(int price) {
         this.price = price;
     }
 
-    public static Price of(String price) {
+    @JsonCreator
+    public static Price of(@JsonProperty("price") String price) {
         validate(price);
         return new Price(FormatConverter.parseToInt(price));
     }
@@ -35,15 +39,12 @@ public class Price {
     }
 
     private static void checkPricePattern(String price) {
-        if (!FormatValidator.isNumberPattern(price)) {
+        if (!FormatValidator.isPositiveNumberPattern(price)) {
             throw new InvalidPriceException(String.format(INVALID_PRICE_EXCEPTION_MESSAGE, price));
         }
     }
 
-    public static Price from(Product product) {
-        return new Price(product.getPrice().getValue());
-    }
-
+    @JsonProperty(value = "price")
     int getValue() {
         return price;
     }

--- a/src/main/java/org/threefour/ddip/product/domain/Product.java
+++ b/src/main/java/org/threefour/ddip/product/domain/Product.java
@@ -1,7 +1,9 @@
 package org.threefour.ddip.product.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 import org.threefour.ddip.audit.BaseGeneralEntity;
 import org.threefour.ddip.member.domain.Member;
 import org.threefour.ddip.product.category.domain.ProductCategory;
@@ -36,6 +38,7 @@ public class Product extends BaseGeneralEntity {
     private Member seller;
 
     @OneToMany(mappedBy = "product", cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true, fetch = LAZY)
+    @JsonManagedReference
     private List<ProductCategory> productCategories;
 
     @OneToMany(mappedBy = "product", cascade = {PERSIST, MERGE, REMOVE}, fetch = LAZY)
@@ -62,27 +65,27 @@ public class Product extends BaseGeneralEntity {
                 .build();
     }
 
-    String getName() {
+    public String getName() {
         return name;
     }
 
-    Price getPrice() {
+    public Price getPrice() {
         return price;
     }
 
-    String getTitle() {
+    public String getTitle() {
         return title;
     }
 
-    String getContent() {
+    public String getContent() {
         return content;
     }
 
-    Member getSeller() {
+    public Member getSeller() {
         return seller;
     }
 
-    List<ProductCategory> getProductCategories() {
+    public List<ProductCategory> getProductCategories() {
         return productCategories;
     }
 
@@ -117,5 +120,11 @@ public class Product extends BaseGeneralEntity {
 
     public void delete() {
         deleteEntity();
+    }
+
+    @PostLoad
+    private void init() {
+        Hibernate.initialize(seller);
+        Hibernate.initialize(productCategories);
     }
 }

--- a/src/main/java/org/threefour/ddip/product/domain/RegisterProductRequest.java
+++ b/src/main/java/org/threefour/ddip/product/domain/RegisterProductRequest.java
@@ -9,6 +9,7 @@ import org.threefour.ddip.product.category.domain.ConnectCategoryRequest;
 @Getter
 @Setter
 public class RegisterProductRequest {
+    private String memberId;
     private ConnectCategoryRequest connectCategoryRequest;
     private String name;
     private String price;

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/MinPrice.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/MinPrice.java
@@ -36,7 +36,7 @@ public class MinPrice {
     }
 
     private static void checkMinPricePattern(String minPrice) {
-        if (!FormatValidator.isNumberPattern(minPrice)) {
+        if (!FormatValidator.isPositiveNumberOrZeroPattern(minPrice)) {
             throw new InvalidPriceException(String.format(INVALID_MIN_PRICE_EXCEPTION_MESSAGE, minPrice));
         }
     }

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountPeriod.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountPeriod.java
@@ -35,7 +35,7 @@ public class PriceDiscountPeriod {
     }
 
     private static void checkPeriodPattern(String priceDiscountPeriod) {
-        if (!FormatValidator.isNumberPattern(priceDiscountPeriod)) {
+        if (!FormatValidator.isPositiveNumberPattern(priceDiscountPeriod)) {
             throw new InvalidPriceDiscountPeriodException(
                     String.format(INVALID_PRICE_DISCOUNT_PERIOD_EXCEPTION_MESSAGE, priceDiscountPeriod)
             );

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountRate.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceDiscountRate.java
@@ -35,7 +35,7 @@ public class PriceDiscountRate {
     }
 
     private static void checkRatePattern(String priceDiscountPercentRate) {
-        if (!FormatValidator.isNumberPattern(priceDiscountPercentRate)) {
+        if (!FormatValidator.isPositiveNumberPattern(priceDiscountPercentRate)) {
             throw new InvalidPriceDiscountRateException(
                     String.format(INVALID_PRICE_DISCOUNT_RATE_EXCEPTION_MESSAGE, priceDiscountPercentRate)
             );

--- a/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceInformation.java
+++ b/src/main/java/org/threefour/ddip/product/priceinformation/domain/PriceInformation.java
@@ -13,7 +13,7 @@ import org.threefour.ddip.product.domain.Price;
 import org.threefour.ddip.product.domain.Product;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.LAZY;
 import static javax.persistence.GenerationType.IDENTITY;
@@ -51,12 +51,12 @@ public class PriceInformation {
     @Column(nullable = false, updatable = false)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     @Builder
     private PriceInformation(
             Long id, Product product, Price price, PriceDiscountPeriod priceDiscountPeriod,
-            PriceDiscountRate priceDiscountRate, Timestamp createdAt,
+            PriceDiscountRate priceDiscountRate, LocalDateTime createdAt,
             NextDiscountedAt nextDiscountedAt, MinPrice minPrice
     ) {
         this.id = id;
@@ -72,7 +72,7 @@ public class PriceInformation {
     public static PriceInformation from(Product product, AutoDiscountRequest autoDiscountRequest) {
         return PriceInformation.builder()
                 .product(product)
-                .price(Price.from(product))
+                .price(product.getPrice())
                 .priceDiscountPeriod(PriceDiscountPeriod.of(autoDiscountRequest.getPriceDiscountPeriod()))
                 .priceDiscountRate(PriceDiscountRate.of(autoDiscountRequest.getPriceDiscountRate()))
                 .nextDiscountedAt(NextDiscountedAt.of(autoDiscountRequest.getFirstDiscountDate()))

--- a/src/main/java/org/threefour/ddip/product/service/ProductService.java
+++ b/src/main/java/org/threefour/ddip/product/service/ProductService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public interface ProductService {
     Long createProduct(RegisterProductRequest registerProductRequest, List<MultipartFile> images);
 
-    Product getProduct(Long productId);
+    Product getProduct(Long productId, boolean isCacheableRequest);
 
     Page<Product> getProducts(Pageable pageable, Short categoryId);
 

--- a/src/main/java/org/threefour/ddip/util/FormatValidator.java
+++ b/src/main/java/org/threefour/ddip/util/FormatValidator.java
@@ -2,8 +2,10 @@ package org.threefour.ddip.util;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.List;
 
 import static org.threefour.ddip.util.EntityConstant.DATE_PATTERN;
+import static org.threefour.ddip.util.RegularExpressionConstant.POSITIVE_INTEGER_OR_ZERO_PATTERN;
 import static org.threefour.ddip.util.RegularExpressionConstant.POSITIVE_INTEGER_PATTERN;
 
 public class FormatValidator {
@@ -15,8 +17,16 @@ public class FormatValidator {
         return value != null;
     }
 
-    public static boolean isNumberPattern(String value) {
+    public static boolean hasValue(List value) {
+        return value != null && !value.isEmpty();
+    }
+
+    public static boolean isPositiveNumberPattern(String value) {
         return value.matches(POSITIVE_INTEGER_PATTERN);
+    }
+
+    public static boolean isPositiveNumberOrZeroPattern(String value) {
+        return value.matches(POSITIVE_INTEGER_OR_ZERO_PATTERN);
     }
 
     public static boolean isDatePattern(String date) {

--- a/src/main/java/org/threefour/ddip/util/RegularExpressionConstant.java
+++ b/src/main/java/org/threefour/ddip/util/RegularExpressionConstant.java
@@ -2,4 +2,5 @@ package org.threefour.ddip.util;
 
 public class RegularExpressionConstant {
     public static final String POSITIVE_INTEGER_PATTERN = "^([1-9]\\d*)$";
+    public static final String POSITIVE_INTEGER_OR_ZERO_PATTERN = "^([1-9]\\d*|0)$";
 }

--- a/src/main/resources/templates/product/registration.html
+++ b/src/main/resources/templates/product/registration.html
@@ -177,6 +177,7 @@
                         <h5>상품 등록</h5>
                         <form class="product-registration" name="f" action="registration-confirm" method="post"
                               enctype="multipart/form-data">
+                            <input type="hidden" name="memberId" id="memberId">
                             <input type="hidden" name="autoDiscountRequest.firstDiscountDate" id="firstDiscountDate">
                             <input type="hidden" name="autoDiscountRequest.priceDiscountPeriod"
                                    id="priceDiscountPeriod">
@@ -508,6 +509,9 @@
         const priceDiscountPeriod = document.getElementById('price-discount-period').value.trim();
         const priceDiscountRate = document.getElementById('price-discount-rate').value.trim();
         const minPrice = document.getElementById('min-price').value.trim();
+
+        // TODO: 회원 연결
+        document.getElementById('memberId').value = '1';
 
         if (firstCategory.length === 0) {
             alert('대분류를 선택해 주세요.');


### PR DESCRIPTION
## resolve #93

## 추가사항
- Redis Cache 설정 적용
    - RedisConfig 클래스
    - Hibernate 의존성
    - HibernateCollectionIdResolver 클래스
    - HibernateCollectionMixIn 클래스
- 포장 객체의 JSON 직렬화, 역직렬화 구현
- Product 엔티티와 매핑된 엔티티들의 JSON 직렬화, 역직렬화 구현
- 상품 상세 조회 기능에 Redis Cache 적용

## 변경사항
- BaseEntity 클래스의 createdAt과 modifiedAt 속성 타입을 LocalDateTime으로 변경
- PriceInformation 클래스의 createdAt 속성 타입을 LocalDateTime으로 변경
- 속성들의 접근 제한자 조정

## 배포
- [ ] 확인
