### PR TITLE
[#120] 상품과 카테고리 엔티티에 식별 관계 매핑된 상품 카테고리 엔티티가 물리적으로 삭제되지 않는 문제 해결 

### DIFF
--- a/src/main/java/org/threefour/ddip/product/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/threefour/ddip/product/category/service/CategoryServiceImpl.java
@@ -13,6 +13,7 @@ import org.threefour.ddip.product.category.repository.ProductCategoryRepository;
 import org.threefour.ddip.product.domain.Product;
 import org.threefour.ddip.util.FormatConverter;
 
+import javax.persistence.EntityManager;
 import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.*;
@@ -24,6 +25,7 @@ import static org.threefour.ddip.product.category.exception.ExceptionMessage.CAT
 public class CategoryServiceImpl implements CategoryService {
     private final CategoryRepository categoryRepository;
     private final ProductCategoryRepository productCategoryRepository;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional(isolation = SERIALIZABLE, timeout = 30)
@@ -52,6 +54,7 @@ public class CategoryServiceImpl implements CategoryService {
     @Override
     @Transactional(isolation = READ_COMMITTED)
     public void updateProductCategories(ConnectCategoryRequest connectCategoryRequest, Product product) {
+        entityManager.clear();
         productCategoryRepository.deleteAllByProductId(product.getId());
         createProductCategories(connectCategoryRequest, product);
     }


### PR DESCRIPTION
## resolve #120

## 변경사항
- 삭제 전 EntityManager 클래스의 clear 메서드를 호출함으로써 영속성 컨텍스트를 초기화하고 부모 엔티티와의 연결 해제

## 배포
- [x] 확인