### PR TITLE
[#172] Member 엔티티에서 Addresses 필드를 직렬화하지 못하는 문제 해결

### DIFF
--- a/src/main/java/org/threefour/ddip/address/domain/Address.java
+++ b/src/main/java/org/threefour/ddip/address/domain/Address.java
@@ -1,7 +1,9 @@
 package org.threefour.ddip.address.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
 import org.threefour.ddip.audit.BaseEntity;
 import org.threefour.ddip.member.domain.Member;
 
@@ -35,5 +37,6 @@ public class Address extends BaseEntity {
 
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "member_id")
+  @JsonBackReference
   private Member member;
 }

--- a/src/main/java/org/threefour/ddip/member/domain/Member.java
+++ b/src/main/java/org/threefour/ddip/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.ColumnDefault;
 import org.threefour.ddip.address.domain.Address;
 import org.threefour.ddip.audit.BaseEntity;
@@ -46,6 +47,7 @@ public class Member extends BaseEntity {
 
   @OneToMany(mappedBy = "member", cascade = {PERSIST, MERGE, REMOVE}, orphanRemoval = true, fetch = LAZY)
   @ToString.Exclude
+  @JsonManagedReference
   private List<Address> addresses;
 
   @ManyToMany(fetch = FetchType.EAGER) //다른방법
@@ -54,4 +56,9 @@ public class Member extends BaseEntity {
           joinColumns = @JoinColumn(name = "member_id"),
           inverseJoinColumns = @JoinColumn(name = "role_id"))
   private List<Role> roles = new ArrayList<>();
+
+  @PostLoad
+  private void init() {
+    Hibernate.initialize(addresses);
+  }
 }


### PR DESCRIPTION
## resolve #172

## 변경사항
- JsonManagedReference, JsonBackReference 어노테이션 적용
- LAZY 로딩되는 addresses 필드의 Hibernate 초기화 설정 추가

## 배포
- [ ] 확인